### PR TITLE
Fix autocomplete for built-in variables

### DIFF
--- a/source/ahk.lua
+++ b/source/ahk.lua
@@ -62,14 +62,20 @@ function OnChar(curChar)
 		return CancelAutoComplete()
 	else
 		local curStyle = editor.StyleAt[editor.CurrentPos-2]
+		local pos = editor:WordStartPosition(editor.CurrentPos)
 		
 		-- Disable AutoComplete on comment/string/error/etc.
 		if isInTable(ignoreStyles, curStyle) then
-			return CancelAutoComplete()
+			-- Allow autocompletion of built-in variables in standard (%-delimited) mode
+			if curStyle == SCE_AHK_ERROR and
+				editor.CharAt[pos-1] == 37 and
+				not isInTable(ignoreStyles, editor.StyleAt[pos-1]) then
+				return false
+			else return CancelAutoComplete()
+			end
 		end
 		
 		-- Disable AutoComplete for words that start with underscore if it's not an object call
-		local pos = editor:WordStartPosition(editor.CurrentPos)
 		-- _ and .
 		if editor.CharAt[pos] == 95 and editor.CharAt[pos-1] ~= 46 then
 			return CancelAutoComplete()


### PR DESCRIPTION
When you start typing `%A_`, the autocomplete box with the list of built-in variables disappears. The `OnChar()` function in ahk.lua is canceling the autocomplete box because the variable name is getting set to the error style because there is not yet an ending `%`. This edit creates an exception to the ignored styles list for this case by checking to see if there is a non-ignored `%` in front of a word if it has the error style.
