### PR TITLE
Fix OnChar to avoid interfering with calltips

### DIFF
--- a/source/ahk.lua
+++ b/source/ahk.lua
@@ -47,13 +47,18 @@ function isAutoCompleteIgnoreException(ignoreStyles, curStyle, pos)
 		editor.CharAt[pos-1] == 37 and not isInTable(ignoreStyles, editor.StyleAt[pos-1])
 end
 
+function isAutoCompleteChar(char)
+	return props['autocomplete.'..props.Language..'.start.characters']:find(char, 1, true)
+end
+
 function OnChar(curChar)
 	-- This function should only run when the Editor pane is focused.
 	if not editor.Focus then return false end
 
 	-- Cancel AutoComplete inside certain lexer-specific styles
+	-- Check curChar to avoid interfering with standard calltip handling
 	local ignoreStyles = lexerIgnoreStyles[editor.Lexer]
-	if ignoreStyles ~= nil then
+	if ignoreStyles ~= nil and isAutoCompleteChar(curChar) then
 		local curStyle = editor.StyleAt[editor.CurrentPos-2]
 		local pos = editor:WordStartPosition(editor.CurrentPos)
 


### PR DESCRIPTION
The problem can be replicated by adding an API (even a fake one) with parameters and the following properties to enable calltips:
```
calltip.ahk1.ignorecase=1
calltip.ahk2.ignorecase=1
calltip.ahk2.parameters.start=(
calltip.ahk2.parameters.end=)
calltip.ahk2.parameters.separators=,
calltip.ahk2.word.characters=$(ahk2.word.characters).#
```
With the API `Fubar(A)`, typing `Fubar("A")` would not close the tooltip, because OnChar was returning true.

This PR fixes it by skipping the autocomplete workarounds if the character being typed is one that would not trigger autocomplete, such `)`.